### PR TITLE
Updating the starting block and the RPC Endpoint of the sei network starter project

### DIFF
--- a/Sei/sei-starter/project.yaml
+++ b/Sei/sei-starter/project.yaml
@@ -21,9 +21,7 @@ network:
   # When developing your project we suggest getting a private API key
   endpoint:
     [
-      "https://sei.kingnodes.com/",
-      "https://rpc.atlantic-2.seinetwork.io/",
-      "https://sei-testnet-2-rpc.brocha.in/",
+      "https://rpc-sei-testnet.rhinostake.com/",
     ]
   # Optionally provide the HTTP endpoint of a full chain dictionary to speed up processing
   dictionary: "https://api.subquery.network/sq/subquery/cosmos-sei-dictionary"
@@ -34,7 +32,7 @@ network:
         - MsgSend
 dataSources:
   - kind: cosmos/Runtime
-    startBlock: 15613354
+    startBlock: 24596905
     mapping:
       file: ./dist/index.js
       handlers:


### PR DESCRIPTION
There is an error documented by one of our users:
![image](https://github.com/subquery/cosmos-subql-starter/assets/81751092/040b4ecb-18d5-413b-a468-5fb358dc4243)

This is due to the fact that the RPC endpoints previously working are no longer working
In addition to this, the RPC endpoints available only go back to a certain block height. This is why the blockheight was also updated in this branch.