### PR TITLE
fix: update publish-deploy.sh to accommodate IPFSCID outputting to a file

### DIFF
--- a/Neutron/neutron-starter/.github/workflows/scripts/publish-deploy.sh
+++ b/Neutron/neutron-starter/.github/workflows/scripts/publish-deploy.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
 
-while getopts p:o: flag
+while getopts p:o:e: flag
 do
     case "${flag}" in
+        e) ENDPOINT=${OPTARG};;
         p) PROJECTNAME=${OPTARG};;
         o) ORG=${OPTARG};;
-        *) echo "Usage: $0 [-p projectname] [-o org]" && exit 1;;
+        *) echo "Usage: $0 [-p projectname] [-o org] [-e endpoint]" && exit 1;;
     esac
 done
 
 IPFSCID=$(npx subql publish -o -f .)
 
-npx subql deployment:deploy -d --ipfsCID="$IPFSCID" --projectName="${PROJECTNAME}" --org="${ORG%/*}"
+# output the CID to ./project-cid
+npx subql publish -o -f .
+
+# run the deploy
+npx subql deployment:deploy -d --ipfsCID="$(<.project-cid)" --projectName="${PROJECTNAME}" --org="${ORG%/*}" --endpoint="${ENDPOINT}"


### PR DESCRIPTION
The output of the `npx subql publish -o -f .` command is some a simple string and this fix updates it to instead read from the `./project-cid` file so it works properly in CI environment. 