### PR TITLE
chore: added more public endpoints

### DIFF
--- a/Kyve/kyve-starter/project.ts
+++ b/Kyve/kyve-starter/project.ts
@@ -35,7 +35,12 @@ const project: CosmosProject = {
      * If you use a rate limited endpoint, adjust the --batch-size and --workers parameters
      * These settings can be found in your docker-compose.yaml, they will slow indexing but prevent your project being rate limited
      */
-    endpoint: ["https://rpc-eu-1.kyve.network"],
+    endpoint: [
+      "https://rpc-kyve.ecostake.com",
+      "https://kyve.rpc.liveraven.net",
+      "https://rpc-kyve.imperator.co",
+      "https://kyve-rpc.ibs.team",
+    ],
     chaintypes: new Map([
       [
         "cosmos.slashing.v1beta1",


### PR DESCRIPTION
Added the following public endpoints since `https://rpc-eu-1.kyve.network` is rate limited and does not work anymore. We will follow up with KYVE's official endpoint once we found a suitable rate limit which also works for SubQuery. In the meantime the following public endpoints where added:

- https://rpc-kyve.ecostake.com
- https://kyve.rpc.liveraven.net
- https://rpc-kyve.imperator.co
- https://kyve-rpc.ibs.team